### PR TITLE
Add optional argument to getFileName

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -96,9 +96,10 @@ module.exports = exports = bindings
 /**
  * Gets the filename of the JavaScript file that invokes this function.
  * Used to help find the root directory of a module.
+ * Optionally accepts an filename argument to skip when searching for the invoking filename
  */
 
-exports.getFileName = function getFileName () {
+exports.getFileName = function getFileName (calling_file) {
   var origPST = Error.prepareStackTrace
     , origSTL = Error.stackTraceLimit
     , dummy = {}
@@ -110,7 +111,13 @@ exports.getFileName = function getFileName () {
     for (var i=0, l=st.length; i<l; i++) {
       fileName = st[i].getFileName()
       if (fileName !== __filename) {
-        return
+        if (calling_file) {
+            if (fileName !== calling_file) {
+              return
+            }
+        } else {
+          return
+        }
       }
     }
   }


### PR DESCRIPTION
I'd like to use node-bindings in [node-pre-gyp](https://github.com/mapbox/node-pre-gyp).

In the case of node-pre-gyp, which packages binaries, the exact relative path is known to the versioned binary `.node` (so multiple tries are not needed). But node-pre-gyp allows complex versioning to be declared in a modules `package.json`. In order to only declare that versioning in one place (package.json and not the js require) it makes sense to provide a node-binding like require shortcut.

So `node-pre-gyp` needs to find out the path to the `package.json` in order to look up the versioning info (and module path). I found the `getFileName` and `getRoot` parts of node-bindings useful for this.

The one problem is that `getFileName` obviously resolves against the calling js file. In my case I want to call it from node-pre-gyp but actually resolve the file that is calling node-pre-gyp. This patch allows that. Let me know if you can think of better ways, but this works well.

For reference this is how I'm using it: https://github.com/mapbox/node-pre-gyp/compare/master...bindings.
