### PR TITLE
Added note for how .node file is searched for

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Error: Could not load the bindings file. Tried:
     ...
 ```
 
+The searching for the `.node` file will originate from the first directory in which has a `package.json` file is found. 
 
 License
 -------


### PR DESCRIPTION
Added a note about how `node-gyp` searches for the `.node` file; how it will begin its search in the first directory it finds which has a `package.json`. This is an important feature that is surprisingly not mentioned at all within the documentation - I, myself, had trouble figuring out what was going wrong when I ran into problems regarding this silent feature.
