### PR TITLE
Replaced __proto__ with Object.assign

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -50,7 +50,9 @@ function bindings (opts) {
   }
   
   // maps `defaults` onto `opts` object
-  Object.keys(defaults).map(i => i in opts || (opts[i] = defaults[i]));
+  Object.keys(defaults).map(function(i) {
+    if (!(i in opts) opts[i] = defaults[i];
+  });
 
   // Get the module root
   if (!opts.module_root) {

--- a/bindings.js
+++ b/bindings.js
@@ -48,7 +48,7 @@ function bindings (opts) {
   } else if (!opts) {
     opts = {}
   }
-  opts.__proto__ = defaults
+  opts = Object.assign({}, defaults, opts);
 
   // Get the module root
   if (!opts.module_root) {

--- a/bindings.js
+++ b/bindings.js
@@ -48,7 +48,9 @@ function bindings (opts) {
   } else if (!opts) {
     opts = {}
   }
-  opts = Object.assign({}, defaults, opts);
+  
+  // maps `defaults` onto `opts` object
+  Object.keys(defaults).map(i => i in opts || (opts[i] = defaults[i]));
 
   // Get the module root
   if (!opts.module_root) {


### PR DESCRIPTION
Modifiying `__proto__` is really bad idea and bad practice, as it'll slow down your program quite a bit and all, so I've replaced it with `Object.assign`.

Citing [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto):

> Warning: Changing the [[Prototype]] of an object is, by the nature of how modern JavaScript engines optimize property accesses, a very slow operation, in every browser and JavaScript engine. The effects on performance of altering inheritance are subtle and far-flung, and are not limited to simply the time spent in obj.__proto__ = ... statement, but may extend to any code that has access to any object whose [[Prototype]] has been altered. If you care about performance you should avoid setting the [[Prototype]] of an object. Instead, create a new object with the desired [[Prototype]] using Object.create().

Object.assign is supported on all node versions > 0.x