### PR TITLE
Add node pre gyp path to search

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -14,6 +14,7 @@ var fs = require('fs')
       , compiled: process.env.NODE_BINDINGS_COMPILED_DIR || 'compiled'
       , platform: process.platform
       , arch: process.arch
+      , nodePreGyp: 'node-v' + process.versions.modules + '-' + process.platform + '-' + process.arch
       , version: process.versions.node
       , bindings: 'bindings.node'
       , try: [
@@ -32,6 +33,8 @@ var fs = require('fs')
         , [ 'module_root', 'build', 'default', 'bindings' ]
           // Production "Release" buildtype binary (meh...)
         , [ 'module_root', 'compiled', 'version', 'platform', 'arch', 'bindings' ]
+          // node-pre-gyp path ./lib/binding/{node_abi}-{platform}-{arch}
+        , [ 'module_root', 'lib', 'binding', 'nodePreGyp', 'bindings' ]
         ]
     }
 
@@ -49,7 +52,7 @@ function bindings (opts) {
   } else if (!opts) {
     opts = {}
   }
-  
+
   // maps `defaults` onto `opts` object
   Object.keys(defaults).map(function(i) {
     if (!(i in opts) opts[i] = defaults[i];

--- a/bindings.js
+++ b/bindings.js
@@ -55,7 +55,7 @@ function bindings (opts) {
 
   // maps `defaults` onto `opts` object
   Object.keys(defaults).map(function(i) {
-    if (!(i in opts) opts[i] = defaults[i];
+    if (!(i in opts)) opts[i] = defaults[i];
   });
 
   // Get the module root

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "c",
     "c++"
   ],
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Nathan Rajlich <nathan@tootallnate.net> (http://tootallnate.net)",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change adds the default node-pre-gyp module_path to search like how [sqlite3](https://github.com/mapbox/node-sqlite3/blob/master/package.json#L12) does their native node module (and others too I'm sure)

This will search in `./lib/binding/{node_abi}-{platform}-{arch}`

It looks like this also addresses [Issue 11](https://github.com/TooTallNate/node-bindings/issues/11)

Also it looked like there is a missing right paren, fixed that