### PR TITLE
Uses actual error code to detect resolution exceptions

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -115,7 +115,7 @@ function bindings(opts) {
       }
       return b;
     } catch (e) {
-      if (!/not find/i.test(e.message)) {
+      if (e.code !== 'MODULE_NOT_FOUND' && e.code !== 'QUALIFIED_PATH_RESOLUTION_FAILED') {
         throw e;
       }
     }


### PR DESCRIPTION
The two following codes are used when a resolution fails.

  - `MODULE_NOT_FOUND` is used by the Node resolution when it fails for any reason
  - `QUALIFIED_PATH_RESOLUTION_FAILED` is thrown by PnP when an unqualified path cannot be successfully resolved to a qualified path (ie when the resolver cannot find a file that map to the specified absolute request even after trying `index.js` / `index.node` / etc alternatives).

I removed the previous check as I think `MODULE_NOT_FOUND` is quite old (even Node 4 has it), but I can add it back if you think that makes sense.