### PR TITLE
Put dummy.stack into Error object, prevents Webpack removing line.

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -169,7 +169,7 @@ exports.getFileName = function getFileName(calling_file) {
 
   // run the 'prepareStackTrace' function above
   Error.captureStackTrace(dummy);
-  dummy.stack;
+  new Error(dummy.stack);
 
   // cleanup
   Error.prepareStackTrace = origPST;


### PR DESCRIPTION
Previously Webpack would minify away the line from apparent lack of side effects. See https://github.com/warpdesign/bindings-webpack for a demo of this.

Solves:
https://github.com/TooTallNate/node-bindings/issues/61
https://github.com/warpdesign/react-explorer/issues/78
https://github.com/TooTallNate/node-bindings/issues/54