### PR TITLE
Fix undefined fileName in getFileName

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -155,7 +155,7 @@ exports.getFileName = function getFileName(calling_file) {
   Error.prepareStackTrace = function(e, st) {
     for (var i = 0, l = st.length; i < l; i++) {
       fileName = st[i].getFileName();
-      if (fileName !== __filename) {
+      if (fileName && fileName !== __filename) {
         if (calling_file) {
           if (fileName !== calling_file) {
             return;


### PR DESCRIPTION
When attempting to find the file name of the caller, getFileName grabs a stack
trace and attempts to walk up it to find the first file name that is not the
bindings.js file. For some reason, in my environment, the bindings.js file
name is 'undefined' (see output below). In this case 'undefined' !== __filename
and the for loop is stopped, leaving fileName undefined and causing an error
when indexOf is invoked on fileName. To fix, an additional check for undefined
fileName is added in the loop.

fileName:  undefined
function:  getFileName
fileName:  undefined
function:  bindings
fileName:  undefined
function:  eval
fileName:  /projects/node-crfpp/node-crfpp-bundle.js
function:  ./node-crfpp.js