### PR TITLE
Add support for node-ffi build path

### DIFF
--- a/bindings.js
+++ b/bindings.js
@@ -55,7 +55,7 @@ var fs = require('fs'),
       ['module_root', 'addon-build', 'default', 'install-root', 'bindings'],
       // node-pre-gyp path ./lib/binding/{node_abi}-{platform}-{arch}
       ['module_root', 'lib', 'binding', 'nodePreGyp', 'bindings'],
-      // node-ffi build
+      // node-ffi build path
       ['module_root', 'build', 'Release', 'obj.target', 'bindings']
     ]
   };

--- a/bindings.js
+++ b/bindings.js
@@ -54,7 +54,9 @@ var fs = require('fs'),
       ['module_root', 'addon-build', 'debug', 'install-root', 'bindings'],
       ['module_root', 'addon-build', 'default', 'install-root', 'bindings'],
       // node-pre-gyp path ./lib/binding/{node_abi}-{platform}-{arch}
-      ['module_root', 'lib', 'binding', 'nodePreGyp', 'bindings']
+      ['module_root', 'lib', 'binding', 'nodePreGyp', 'bindings'],
+      // node-ffi build
+      ['module_root', 'build', 'Release', 'obj.target', 'bindings']
     ]
   };
 


### PR DESCRIPTION
[node-ffi](https://github.com/node-ffi/node-ffi) builds to node_modules/ffi/build/Release/obj.target/ffi_bindings.node. This one-line change allows node-bindings to look for that file.

This is useful particularly because with the geekuillaume's [fork](https://github.com/geekuillaume/pkg) of ZEIT's pkg, you can now package native node files. This change is required if you want to package anything that depends on node-ffi, since it also depends on node-bindings, and otherwise, pkg can't find ffi-bindings.node on compile.